### PR TITLE
fix: add create, list authority for argo-deploy-sa

### DIFF
--- a/workflow-templates/helm-operator/helmrelease-rbac.yaml
+++ b/workflow-templates/helm-operator/helmrelease-rbac.yaml
@@ -33,6 +33,8 @@ rules:
   - get
   - watch
   - patch
+  - create
+  - list
 - apiGroups:
   - apiextensions.k8s.io
   resources:


### PR DESCRIPTION
* argo-deploy-sa serviceaccount needs to create, list namespaces resource in k8s cluster.