### PR TITLE
fix: use 'argo' namespace by default

### DIFF
--- a/workflow-templates/helm-operator/helmrelease-rbac.yaml
+++ b/workflow-templates/helm-operator/helmrelease-rbac.yaml
@@ -4,7 +4,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: argo-deploy-sa
-  namespace: default
+  namespace: argo
 ---
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
@@ -17,7 +17,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: argo-deploy-sa
-  namespace: default
+  namespace: argo
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole


### PR DESCRIPTION
* use `argo` namespace instead `default` namespace