### PR TITLE
remove urlencode in prepare-manifest wftpl

### DIFF
--- a/templates/decapod-yaml/prepare-manifest-wftpl.yaml
+++ b/templates/decapod-yaml/prepare-manifest-wftpl.yaml
@@ -69,8 +69,7 @@ spec:
         set -e
         cd /mnt/workdir
         if [[ "${GIT_USERNAME}" != "" ]] && [[ "${GIT_PASSWORD}" != "" ]]; then
-          ENCODED_PASSWORD=$(urlencode $GIT_PASSWORD)
-          CLONE_URL=$(echo $SITE_YAML_URL | sed 's/\/\//\/\/'"$GIT_USERNAME"':'"$ENCODED_PASSWORD"'@/')
+          CLONE_URL=$(echo $SITE_YAML_URL | sed 's/\/\//\/\/'"$GIT_USERNAME"':'"$GIT_PASSWORD"'@/')
         else
           CLONE_URL=$SITE_YAML_URL
         fi


### PR DESCRIPTION
* password를 항상 encode하지 않아도 된다. urlencode를 사용하지 않고 git clone을 하도록 수정.