### PR TITLE
update service-mesh-wf to deploy both istio controlplane and gateway HR

### DIFF
--- a/workflows/service-mesh-wf.yaml
+++ b/workflows/service-mesh-wf.yaml
@@ -37,6 +37,7 @@ spec:
             value: |
               [
                 "kiali-operator",
-                "service-mesh-resource"
+                "service-mesh-controlplane",
+                "service-mesh-gateway"
               ]
         dependencies: [operator]


### PR DESCRIPTION
https://github.com/openinfradev/decapod-base-yaml/pull/46 에서 controlplane과 gateway를 별도의 helm release로 분리하였으므로, workflow에도 반영이 되어야함.

default로 (gating 용도로) controlplane과 gateway를 모두 배포하되, 실제 사이트 구축 시에는 site별 workflow를 사용하여 gateway를 제외하고 배포 가능함.