### PR TITLE
add post-process feature for tks

### DIFF
--- a/templates/decapod-apps/tks-lma-federation-wftpl.yaml
+++ b/templates/decapod-apps/tks-lma-federation-wftpl.yaml
@@ -1,0 +1,149 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: lma-federation
+  namespace: argo
+spec:
+  entrypoint: deploy
+  arguments:
+    parameters:
+    - name: site_name
+      value: "hanu-reference"
+    - name: app_name
+      value: "lma"
+    - name: label
+      value: "hanu-app1"
+    - name: repository_url
+      value: "https://github.com/openinfradev/decapod-manifests"
+  templates:
+  - name: deploy
+    steps:
+    - - name: process
+        template: argocd
+        arguments:
+          parameters:
+          - name: site_name
+            value: "hanu-reference"
+          - name: app_name
+            value: "lma"
+          - name: repository_url
+            value: "https://github.com/openinfradev/decapod-manifests"
+    - - name: postprocess
+        template: tks-client-epregister
+        arguments:
+          parameters:
+          - name: tks
+            value: "127.0.0.1"
+          - name: clusterid
+            value: "6abead61-ff2a-4af4-8f41-d2c44c745de7"
+          - name: appgroupid
+            value: "abbead61-ff2a-4af4-8f41-d2c44c745de7"
+          - name: clusterep
+          #   value: "192.168.5.61"
+          # - name: eplist
+          #   value: "{\"1\":\"127.0.0.1\",\"2\":\"127.0.0.1:10232\"}"
+
+  - name: argocd
+    dag:
+      tasks:
+      - name: operator
+        templateRef:
+          name: create-application
+          template: AppGroup
+        arguments:
+          parameters: 
+          - name: list
+            value: |
+              [
+                { "path": "prometheus-operator", "namespace": "lma" },
+                { "path": "eck-operator", "namespace": "elastic-system" },
+                { "path": "fluentbit-operator", "namespace": "lma" }
+              ]
+        dependencies: []
+      - name: logging
+        templateRef:
+          name: create-application
+          template: AppGroup
+        arguments:
+          parameters: 
+          - name: list
+            value: |
+              [
+                { "path": "eck-resource", "namespace": "lma" },
+                { "path": "fluentbit", "namespace": "lma" },
+                { "path": "kubernetes-event-exporter", "namespace": "lma" }
+              ]
+        dependencies: [operator]
+      - name: prepare-lma
+        templateRef:
+          name: create-application
+          template: AppGroup
+        arguments:
+          parameters: 
+          - name: list
+            value: |
+              [
+                { "path": "thanos-config", "namespace": "lma" }
+              ]
+        dependencies: [operator]
+
+      - name: prometheus
+        templateRef:
+          name: create-application
+          template: AppGroup
+        arguments:
+          parameters: 
+          - name: list
+            value: |
+              [
+                { "path": "prometheus", "namespace": "lma" },
+                { "path": "kube-state-metrics", "namespace": "lma" },
+                { "path": "prometheus-process-exporter", "namespace": "lma" },
+                { "path": "prometheus-pushgateway", "namespace": "lma" },
+                { "path": "prometheus-node-exporter", "namespace": "lma" },
+                { "path": "prometheus-adapter", "namespace": "lma" },
+                { "path": "addons", "namespace": "lma" }
+              ]
+        dependencies: [prepare-lma]
+
+      - name: federation
+        templateRef:
+          name: create-application
+          template: AppGroup
+        arguments:
+          parameters: 
+          - name: list
+            value: |
+              [
+                { "path": "prometheus-fed-master", "namespace": "lma" },
+                { "path": "fed-addons", "namespace": "lma" },
+                { "path": "thanos", "namespace": "lma" }
+              ]
+        dependencies: [prometheus,logging]
+
+      - name: grafana
+        templateRef:
+          name: create-application
+          template: AppGroup
+        arguments:
+          parameters: 
+          - name: list
+            value: |
+              [
+                { "path": "grafana", "namespace": "lma" }
+              ]
+        dependencies: [federation]
+
+  - name: tks-client-epregister
+    inputs:
+      parameters:
+      - name: tks
+      - name: clusterid
+      - name: appgroupid
+      - name: eplist
+    container:
+      # run cowsay with that message input parameter as args
+      image: siim/ep2tks:0.0.1
+      command: ["/app/ep2tks"]
+      args: ["-tks","{{inputs.parameters.tks}}","-clusterep","{{inputs.parameters.clusterep}}",
+        "-appgroupid","{{inputs.parameters.appgroupid}}","-clusterid","{{inputs.parameters.clusterid}}"]

--- a/templates/decapod-apps/tks-lma-federation-wftpl.yaml
+++ b/templates/decapod-apps/tks-lma-federation-wftpl.yaml
@@ -20,14 +20,6 @@ spec:
     steps:
     - - name: process
         template: argocd
-        arguments:
-          parameters:
-          - name: site_name
-            value: "hanu-reference"
-          - name: app_name
-            value: "lma"
-          - name: repository_url
-            value: "https://github.com/openinfradev/decapod-manifests"
     - - name: postprocess
         template: tks-client-epregister
         arguments:
@@ -38,10 +30,22 @@ spec:
             value: "6abead61-ff2a-4af4-8f41-d2c44c745de7"
           - name: appgroupid
             value: "abbead61-ff2a-4af4-8f41-d2c44c745de7"
-          - name: clusterep
-          #   value: "192.168.5.61"
+          # 3-ways for transfer information (about applications)
+          #   1. eplist 변수에 json 형태로 어플리케이션별 모든 url 제공 "{"1":"127.0.0.1","2":"127.0.0.1:10232"}"
+          #   2. clusterep에 클러스터에 대한 ip혹은 dns를 명시하고 epportlist변수에 어플리케이션별 포트를 제공 "{"1":"30000","2":"30005"}"
+          #   3. clusterep에 클러스터에 대한 ip 혹은 dns를 적용하여 미리 정해진 내용을 등록하도록 유도 - 현재는 30007 포트만 prometheus sidecar 서비스로 등재
+          # (For Example)
+          # (case 1)
           # - name: eplist
           #   value: "{\"1\":\"127.0.0.1\",\"2\":\"127.0.0.1:10232\"}"
+          # (case 2)
+          # - name: clusterep
+          #   value: "taco.mycluster.com"
+          # - name: epportlist
+          #   value: "{"1":"30000","2":"30005"}"
+          # (case 3)
+          # - name: clusterep
+          #   value: "192.168.0.1"
 
   - name: argocd
     dag:
@@ -140,10 +144,10 @@ spec:
       - name: tks
       - name: clusterid
       - name: appgroupid
-      - name: eplist
+      - name: clusterep
     container:
       # run cowsay with that message input parameter as args
-      image: siim/ep2tks:0.0.1
+      image: ghcr.io/openinfradev/ep2tks:v0.1.0
       command: ["/app/ep2tks"]
       args: ["-tks","{{inputs.parameters.tks}}","-clusterep","{{inputs.parameters.clusterep}}",
         "-appgroupid","{{inputs.parameters.appgroupid}}","-clusterid","{{inputs.parameters.clusterid}}"]


### PR DESCRIPTION
lma-federation-wf에 tks에 연동하여 endpoint를 등록하는 post process추가
입력하는 방법은 다음 3가지
1. eplist 변수에 json 형태로 어플리케이션별 모든 url 제공 "{\"1\":\"127.0.0.1\",\"2\":\"127.0.0.1:10232\"}"
2. clusterep에 클러스터에 대한 ip혹은 dns를 명시하고 epportlist변수에 어플리케이션별 포트를 제공 "{\"1\":\"30000\",\"2\":\"30005\"}"
3. clusterep에 클러스터에 대한 ip 혹은 dns를 적용하여 미리 정해진 내용을 등록하도록 유도 - 현재는 30007 포트만 prometheus sidecar 서비스로 등재