### PR TITLE
Change storageclass to 'taco-storage'

### DIFF
--- a/templates/decapod-yaml/prepare-manifest-wftpl.yaml
+++ b/templates/decapod-yaml/prepare-manifest-wftpl.yaml
@@ -28,7 +28,7 @@ spec:
       resources:
         requests:
           storage: 10Mi
-      storageClassName: rbd
+      storageClassName: taco-storage
   templates:
   - name: startpoint
     steps:


### PR DESCRIPTION
taco에서 사용하는 기본 스토리지클래스 이름이 `taco-storage`로 변경되어, 관련 변수를 수정합니다.