### PR TITLE
servicemesh refactoring

### DIFF
--- a/templates/argo-cd/createapp-wftpl.yaml
+++ b/templates/argo-cd/createapp-wftpl.yaml
@@ -37,7 +37,7 @@ spec:
         ./argocd app get $PATH 
         if [[ $? -ne 0 ]]; then
           # create new application if not exists.
-          ./argocd app create $PATH --repo $REPO --revision $REVISION --path $SITE_NAME/$APP_NAME/$PATH --dest-namespace $NAMESPACE --dest-name $SITE_NAME --project $APP_NAME --directory-recurse
+          ./argocd app create $PATH --repo $REPO --revision $REVISION --path $SITE_NAME/$APP_NAME/$PATH --dest-namespace $NAMESPACE --dest-name $SITE_NAME --project $APP_NAME --label app=$APP_NAME --directory-recurse
         fi
 
         ./argocd app set $PATH --sync-policy automated --auto-prune

--- a/templates/decapod-apps/service-mesh-wf.yaml
+++ b/templates/decapod-apps/service-mesh-wf.yaml
@@ -7,42 +7,183 @@ spec:
   entrypoint: deploy
   arguments:
     parameters:
-    - name: site_name
-      value: "hanu-reference"
-    - name: app_name
-      value: "service-mesh"
-    - name: repository_url
-      value: "https://github.com/openinfradev/decapod-manifests"
-    - name: revision
-      value: main
+      - name: site_name
+        value: hanu-reference
+      - name: app_name
+        value: service-mesh
+      - name: repository_url
+        value: 'https://github.com/openinfradev/decapod-manifests'
+      - name: revision
+        value: main
   templates:
-  - name: deploy
-    dag:
-      tasks:
-      - name: operator
-        templateRef:
-          name: create-application
-          template: AppGroup
-        arguments:
-          parameters: 
-          - name: list
-            value: |
-              [
-                { "path": "istio-operator", "namespace": "istio-system" },
-                { "path": "jaeger-operator", "namespace": "lma" }
-              ]
-        dependencies: []
-      - name: resource
-        templateRef:
-          name: create-application
-          template: AppGroup
-        arguments:
-          parameters: 
-          - name: list
-            value: |
-              [
-                { "path": "kiali-operator", "namespace": "istio-system" },
-                { "path": "service-mesh-controlplane", "namespace": "istio-system" },
-                { "path": "service-mesh-gateway", "namespace": "istio-system" }
-              ]
-        dependencies: [operator]
+    - name: deploy
+      dag:
+        tasks:
+          - name: create-eck-secret
+            template: copy-eck-secret
+            arguments:
+              parameters:
+                - name: secret_name
+                  value: eck-elasticsearch-es-http-certs-public
+                - name: source_namespace
+                  value: lma
+                - name: target_namespace
+                  value: istio-system
+          - name: istio-operator
+            arguments:
+              parameters:
+                - name: list
+                  value: |
+                    [
+                      { "path": "istio-operator", "namespace": "istio-operator" }
+                    ]
+            templateRef:
+              name: create-application
+              template: AppGroup
+            dependencies:
+              - create-eck-secret
+          - name: istio-controlplane
+            arguments:
+              parameters:
+                - name: list
+                  value: |
+                    [
+                      { "path": "servicemesh-controlplane", "namespace": "istio-system" }
+                    ]
+            templateRef:
+              name: create-application
+              template: AppGroup
+            dependencies:
+              - istio-operator
+          - name: istio-gateway
+            arguments:
+              parameters:
+                - name: list
+                  value: |
+                    [
+                      { "path": "servicemesh-gateway", "namespace": "istio-system" }
+                    ]
+            templateRef:
+              name: create-application
+              template: AppGroup
+            dependencies:
+              - istio-controlplane
+          - name: jaeger-kiali-operator
+            arguments:
+              parameters:
+                - name: list
+                  value: |
+                    [
+                      { "path": "jaeger-operator", "namespace": "istio-system" },
+                      { "path": "kiali-operator", "namespace": "istio-system" }
+                    ]
+            templateRef:
+              name: create-application
+              template: AppGroup
+            dependencies:
+              - istio-controlplane
+          - name: servicemesh-jaeger-kiali-resource
+            arguments:
+              parameters:
+                - name: list
+                  value: |
+                    [
+                      { "path": "servicemesh-jaeger-resource", "namespace": "istio-system" },
+                      { "path": "servicemesh-kiali-resource", "namespace": "istio-system" }
+                    ]
+            templateRef:
+              name: create-application
+              template: AppGroup
+            dependencies:
+              - jaeger-kiali-operator
+          - name: grafana-prometheus-resource
+            arguments:
+              parameters:
+                - name: list
+                  value: |
+                    [
+                      { "path": "servicemesh-grafana-dashboard", "namespace": "istio-system" },
+                      { "path": "servicemesh-prometheusmonitor", "namespace": "istio-system" },
+                      { "path": "servicemesh-prometheusrule", "namespace": "istio-system" }
+                    ]
+            templateRef:
+              name: create-application
+              template: AppGroup
+            dependencies:
+              - jaeger-kiali-operator
+          - name: sync-app
+            template: sync-app
+            arguments: {}
+            dependencies:
+              - grafana-prometheus-resource
+    - name: copy-eck-secret
+      arguments: {}
+      inputs:
+        parameters:
+          - name: secret_name
+          - name: source_namespace
+          - name: target_namespace
+      outputs: {}
+      metadata: {}
+      container:
+        name: copy-eck-secret
+        image: 'k8s.gcr.io/hyperkube:v1.18.6'
+        command:
+          - /bin/bash
+          - '-c'
+          - |
+            function log() {
+              level=$1
+              msg=$2
+              date=$(date '+%F %H:%M:%S')
+              echo "[$date] $level     $msg"
+            }
+
+            kubectl get ns ${TARGET_NAMESPACE}
+            if [[ $? =~ 1 ]]; then
+              kubectl create ns ${TARGET_NAMESPACE}
+              kubectl label ns ${TARGET_NAMESPACE} name=lma
+              log "INFO" "${TARGET_NAMESPACE} successfully created."
+            fi
+
+            kubectl get secret ${SECRET_NAME}
+            if [[ $? =~ 1 ]]; then
+              kubectl get secret ${SECRET_NAME} -n ${SOURCE_NAMESPACE} -o yaml \
+              | grep -v '^\s*namespace:\s' \
+              | kubectl apply -n ${TARGET_NAMESPACE} -f -
+              log "INFO" "${SECRET_NAME} successfully created."
+            fi
+        env:
+          - name: SECRET_NAME
+            value: '{{inputs.parameters.secret_name}}'
+          - name: SOURCE_NAMESPACE
+            value: '{{inputs.parameters.source_namespace}}'
+          - name: TARGET_NAMESPACE
+            value: '{{inputs.parameters.target_namespace}}'
+        resources: {}
+      activeDeadlineSeconds: 900
+      retryStrategy:
+        limit: 2
+    - name: sync-app
+      arguments: {}
+      inputs: {}
+      outputs: {}
+      metadata: {}
+      container:
+        name: sync-app
+        image: 'docker.io/sktdev/argocd:latest'
+        command:
+          - /bin/bash
+          - '-c'
+          - |
+            ./argocd login $ARGO_SERVER --insecure --username $ARGO_USERNAME \
+            --password $ARGO_PASSWORD
+
+            ./argocd app sync -l app=service-mesh
+        envFrom:
+          - secretRef:
+              name: decapod-argocd-config
+        resources: {}
+      activeDeadlineSeconds: 900
+      retryStrategy:
+        limit: 2


### PR DESCRIPTION
- helm-chart 가 먼저 적용되어야 함.
   관련 PR: [openinfradev/helm-charts/pull/48]

- decapod-base-yaml 이 먼저 적용되어야 함
   관련 PR: [openinfradev/decapod-base-yaml/pull/88]

- decapod-site 가 먼저 적용되어야 함
   관련 PR: [openinfradev/decapod-site/pull/39]

- istio-system ns 는 servicemesh-controlplane 차트에서는 생성하지 않고 workflow 에서 생성함 (argocd app 으로 삭제하면 istio-system ns 가 같이 삭제되기 때문)

- 설치 마지막에 argocd app sync -l app=service-mesh 로 모든 앱에 sync 를 호출함
  - Missing 이나 OutOfSync 로 변하는 app 이 존재하여 sync 를 호출하면 해결됨
  - create-application workflowtemplate 에서 app 생성시에 app=service-mesh 라벨을 추가함

- 아래 label 을 노드에 추가해야 함 (추후 tacoplay 에 추가 예정)
> 1. servicemesh control node
>     servicemesh=enabled
> 
> 2. servicemesh ingress node
>     taco-ingress-gateway=enabled
> 
> 3. servicemesh egress node
>     taco-egress-gateway=enabled


- Ingress 와 resources 의 값 cpu: 1 이 cpu:'1' 로 설정되어 outofsync 나는 것을 해결하기 위해 추가해야 함 (추후 tacoplay 에 추가 예정)
```
apiVersion: v1
data:
  accounts.admin: apiKey, login
  application.instanceLabelKey: argocd.argoproj.io/instance
  resource.customizations: |
    jaegertracing.io/Jaeger:
      ignoreDifferences: |
        jsonPointers:
        - /spec/collector/resources
      health.lua: |
        health_status = {}
        health_status.status = "Healthy"
        health_status.message = "Jaeger Controlplane is Running"
        return health_status
    networking.k8s.io/Ingress:
      health.lua: |
        health_status = {}
        health_status.status = "Healthy"
        health_status.message = "Jaeger Ingress is Running"
        return health_status
  url: https://argocd.example.com
kind: ConfigMap
...
```


