### PR TITLE
fix: added plaintext option to argocd cli

### DIFF
--- a/templates/argo-cd/createapp-wftpl.yaml
+++ b/templates/argo-cd/createapp-wftpl.yaml
@@ -30,7 +30,7 @@ spec:
       - -c
       - |
         # log into Argo CD server
-        ./argocd login $ARGO_SERVER --insecure --username $ARGO_USERNAME \
+        ./argocd login $ARGO_SERVER --plaintext --insecure --username $ARGO_USERNAME \
         --password $ARGO_PASSWORD
 
         # check if app already exists.

--- a/templates/argo-cd/prepare-argocd-wftpl.yaml
+++ b/templates/argo-cd/prepare-argocd-wftpl.yaml
@@ -52,7 +52,7 @@ spec:
         - /bin/bash
         - '-c'
         - |
-          ./argocd login $ARGO_SERVER --insecure --username $ARGO_USERNAME \
+          ./argocd login $ARGO_SERVER --plaintext --insecure --username $ARGO_USERNAME \
           --password $ARGO_PASSWORD
 
           ./argocd proj get lma

--- a/templates/decapod-apps/remove-servicemesh-all-wftpl.yaml
+++ b/templates/decapod-apps/remove-servicemesh-all-wftpl.yaml
@@ -155,7 +155,7 @@ spec:
               date=$(date '+%F %H:%M:%S')
               echo "[$date] $level     $msg"
             }
-            ./argocd login $ARGO_SERVER --insecure --username $ARGO_USERNAME \
+            ./argocd login $ARGO_SERVER --plaintext --insecure --username $ARGO_USERNAME \
             --password $ARGO_PASSWORD
 
             ./argocd app list -p $APP_NAME -o name | xargs ./argocd app delete -y

--- a/templates/decapod-apps/service-mesh-wf.yaml
+++ b/templates/decapod-apps/service-mesh-wf.yaml
@@ -176,7 +176,7 @@ spec:
           - /bin/bash
           - '-c'
           - |
-            ./argocd login $ARGO_SERVER --insecure --username $ARGO_USERNAME \
+            ./argocd login $ARGO_SERVER --plaintext --insecure --username $ARGO_USERNAME \
             --password $ARGO_PASSWORD
 
             ./argocd app sync -l app=service-mesh


### PR DESCRIPTION
* plaintext option이 없으면 WARNING prompt로 TLS 없이 설정되었다고 접속하겠냐고 물어봄
