### PR TITLE
Add prepare-etcd-secret for lma

### DIFF
--- a/templates/decapod-apps/lma-uniformed-wftpl.yaml
+++ b/templates/decapod-apps/lma-uniformed-wftpl.yaml
@@ -56,7 +56,8 @@ spec:
           - name: list
             value: |
               [
-                { "path": "thanos-config", "namespace": "lma" }
+                { "path": "thanos-config", "namespace": "lma" },
+                { "path": "prepare-etcd-secret", "namespace": "lma" }
               ]
         dependencies: [operator]
 


### PR DESCRIPTION
LMA workflow에 prepare-etcd-secret helm chart를 추가하였습니다.
이 helm chart는 etcd secret을 만들고, 이 secret은 prometheus 실행을 위해 필수적으로 필요합니다.

관련 PR: https://github.com/openinfradev/decapod-site/pull/57