### PR TITLE
rename tasks to avoid confusion

### DIFF
--- a/templates/argo-cd/createapp-wftpl.yaml
+++ b/templates/argo-cd/createapp-wftpl.yaml
@@ -60,12 +60,12 @@ spec:
         - name: REVISION
           value: "{{workflow.parameters.revision}}"
 
-  - name: AppGroup
+  - name: installApps
     inputs:
       parameters:
       - name: list
     steps:
-    - - name: "InstallAppGroup"
+    - - name: "InstallApps"
         template: createApp
         arguments:
           parameters:

--- a/templates/decapod-apps/lma-uniformed-wftpl.yaml
+++ b/templates/decapod-apps/lma-uniformed-wftpl.yaml
@@ -22,7 +22,7 @@ spec:
       - name: operator
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -36,7 +36,7 @@ spec:
       - name: logging
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -50,7 +50,7 @@ spec:
       - name: prepare-lma
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -64,7 +64,7 @@ spec:
       - name: prometheus
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -83,7 +83,7 @@ spec:
       - name: federation
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -96,7 +96,7 @@ spec:
       - name: grafana
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list

--- a/templates/decapod-apps/openstack-components-wf.yaml
+++ b/templates/decapod-apps/openstack-components-wf.yaml
@@ -22,7 +22,7 @@ spec:
       - name: base
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -36,7 +36,7 @@ spec:
       - name: compute-kit 
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -50,7 +50,7 @@ spec:
       - name: addon 
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -64,7 +64,7 @@ spec:
       - name: sona
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list

--- a/templates/decapod-apps/openstack-infra-wftpl.yaml
+++ b/templates/decapod-apps/openstack-infra-wftpl.yaml
@@ -22,7 +22,7 @@ spec:
       - name: operator
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list

--- a/templates/decapod-apps/service-mesh-wf.yaml
+++ b/templates/decapod-apps/service-mesh-wf.yaml
@@ -39,7 +39,7 @@ spec:
                     ]
             templateRef:
               name: create-application
-              template: AppGroup
+              template: installApps
             dependencies:
               - create-eck-secret
           - name: istio-controlplane
@@ -52,7 +52,7 @@ spec:
                     ]
             templateRef:
               name: create-application
-              template: AppGroup
+              template: installApps
             dependencies:
               - istio-operator
           - name: istio-gateway
@@ -65,7 +65,7 @@ spec:
                     ]
             templateRef:
               name: create-application
-              template: AppGroup
+              template: installApps
             dependencies:
               - istio-controlplane
           - name: jaeger-kiali-operator
@@ -79,7 +79,7 @@ spec:
                     ]
             templateRef:
               name: create-application
-              template: AppGroup
+              template: installApps
             dependencies:
               - istio-controlplane
           - name: servicemesh-jaeger-kiali-resource
@@ -93,7 +93,7 @@ spec:
                     ]
             templateRef:
               name: create-application
-              template: AppGroup
+              template: installApps
             dependencies:
               - jaeger-kiali-operator
           - name: grafana-prometheus-resource
@@ -108,7 +108,7 @@ spec:
                     ]
             templateRef:
               name: create-application
-              template: AppGroup
+              template: installApps
             dependencies:
               - jaeger-kiali-operator
           - name: sync-app

--- a/templates/decapod-apps/tks-lma-federation-wftpl.yaml
+++ b/templates/decapod-apps/tks-lma-federation-wftpl.yaml
@@ -55,7 +55,7 @@ spec:
       - name: operator
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -69,7 +69,7 @@ spec:
       - name: logging
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -83,7 +83,7 @@ spec:
       - name: prepare-lma
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -96,7 +96,7 @@ spec:
       - name: prometheus
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -115,7 +115,7 @@ spec:
       - name: federation
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list
@@ -128,7 +128,7 @@ spec:
       - name: grafana
         templateRef:
           name: create-application
-          template: AppGroup
+          template: installApps
         arguments:
           parameters: 
           - name: list


### PR DESCRIPTION
앞으로 appGroup이라는 용어는 LMA, service-mesh 와 같은 단위에 사용하기로 하였기에 혼선을 피하기 위해 task명을 변경합니다