### PR TITLE
TACODEV-909: add a new workflow for user-cluster creation

### DIFF
--- a/templates/argo-additional-rbac.yaml
+++ b/templates/argo-additional-rbac.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: argo-additional-crb
 roleRef:

--- a/templates/argo-cd/createapp-wftpl.yaml
+++ b/templates/argo-cd/createapp-wftpl.yaml
@@ -20,29 +20,36 @@ spec:
       parameters:
       - name: path
       - name: namespace
+      - name: target_cluster
     activeDeadlineSeconds: 900
     container:
       name: 'create'
-      image: docker.io/sktdev/argocd:latest
+      image: ghcr.io/openinfradev/argocd-cli:v2.0.1
       imagePullPolicy: IfNotPresent
       command:
       - /bin/bash
       - -c
       - |
+        CD_APP=${SITE_NAME:0:8}-$PATH
+        echo "argo-cd application name: $CD_APP"
         # log into Argo CD server
         ./argocd login $ARGO_SERVER --plaintext --insecure --username $ARGO_USERNAME \
         --password $ARGO_PASSWORD
 
         # check if app already exists.
-        ./argocd app get $PATH 
+        ./argocd app get $CD_APP 
         if [[ $? -ne 0 ]]; then
+          echo "$CD_APP application is not in server"
           # create new application if not exists.
-          ./argocd app create $PATH --repo $REPO --revision $REVISION --path $SITE_NAME/$APP_NAME/$PATH --dest-namespace $NAMESPACE --dest-name $SITE_NAME --project $APP_NAME --label app=$APP_NAME --directory-recurse
+          ./argocd app create $CD_APP --repo $REPO --revision $REVISION --path $SITE_NAME/$TACO_APP/$PATH --dest-namespace $NAMESPACE --dest-name $TARGET_CLUSTER --project $TACO_APP --label app=$TACO_APP --directory-recurse
+          if [[ $? -ne 0 ]]; then
+            exit $?
+          fi
         fi
 
-        ./argocd app set $PATH --sync-policy automated --auto-prune
-        ./argocd app sync $PATH --async
-        ./argocd app wait $PATH --health
+        ./argocd app set $CD_APP --sync-policy automated --auto-prune
+        ./argocd app sync $CD_APP --async
+        ./argocd app wait $CD_APP --health
       envFrom:
         - secretRef:
             name: "decapod-argocd-config"
@@ -51,7 +58,9 @@ spec:
           value: "{{inputs.parameters.path}}"
         - name: SITE_NAME
           value: "{{workflow.parameters.site_name}}"
-        - name: APP_NAME
+        - name: TARGET_CLUSTER
+          value: "{{inputs.parameters.target_cluster}}"
+        - name: TACO_APP
           value: "{{workflow.parameters.app_name}}"
         - name: NAMESPACE
           value: "{{inputs.parameters.namespace}}"
@@ -71,4 +80,19 @@ spec:
           parameters:
           - {name: path, value: "{{item.path}}"}
           - {name: namespace, value: "{{item.namespace}}"}
+          - {name: target_cluster, value: "{{workflow.parameters.site_name}}"}
+        withParam: "{{inputs.parameters.list}}"
+
+  - name: AppGroupOnAdmin
+    inputs:
+      parameters:
+      - name: list
+    steps:
+    - - name: "InstallAppGroup"
+        template: createApp
+        arguments:
+          parameters:
+          - {name: path, value: "{{item.path}}"}
+          - {name: namespace, value: "{{item.namespace}}"}
+          - {name: target_cluster, value: "{{workflow.parameters.tks_admin}}"}
         withParam: "{{inputs.parameters.list}}"

--- a/templates/argo-cd/prepare-argocd-wftpl.yaml
+++ b/templates/argo-cd/prepare-argocd-wftpl.yaml
@@ -8,7 +8,8 @@ spec:
   arguments:
     parameters:
     - name: argo_server
-      value: "decapod-argocd-server.argo.svc:80"
+      value: "argo-cd-argocd-server.argo.svc:80"
+      # value: "decapod-argocd-server.argo.svc:80"
     - name: argo_username
       value: "admin"
     - name: argo_password
@@ -69,6 +70,12 @@ spec:
           if [[ $? != 0 ]]; then
             ./argocd proj create openstack --dest "*,*" --src "*" --allow-cluster-resource "*/*"
           fi
+
+          ./argocd proj get tks-cluster
+          if [[ $? != 0 ]]; then
+            ./argocd proj create tks-cluster --dest "*,*" --src "*" --allow-cluster-resource "*/*"
+          fi
+
       env:
         - name: ARGO_SERVER
           value: '{{workflow.parameters.argo_server}}'

--- a/templates/decapod-apps/create-usercluster-wftpl.yaml
+++ b/templates/decapod-apps/create-usercluster-wftpl.yaml
@@ -1,0 +1,51 @@
+apiVersion: argoproj.io/v1alpha1
+kind: WorkflowTemplate
+metadata:
+  name: create-usercluster
+  namespace: argo
+spec:
+  entrypoint: deploy
+  arguments:
+    parameters:
+    - name: site_name
+      # value: "YOUR_CLUSTER_NAME"
+      value: "011b88fa-4d53-439f-9336-67845f994051"
+    - name: tks_admin
+      value: "tks-admin"
+    - name: app_name
+      value: "tks-cluster"
+    - name: repository_url
+      value: "https://github.com/tks-management/011b88fa-4d53-439f-9336-67845f994051-manifests.git"
+      # value: "https://github.com/tks-management/YOUR_CONTRACT_ID-manifests"
+    - name: revision
+      value: main
+  templates:
+  - name: deploy
+    dag:
+      tasks:
+        - name: k8s-by-capi
+          templateRef:
+            name: create-application
+            template: AppGroupOnAdmin
+          arguments:
+            parameters: 
+            - name: list
+              value: |
+                [
+                  { "path": "cluster-api-aws", "namespace": "default" }
+                ]
+          dependencies: []
+        - name: ready-for-cni-and-csi
+          templateRef:
+            name: create-application
+            template: AppGroup
+          arguments:
+            parameters: 
+            - name: list
+              value: |
+                [
+                  { "path": "ingress-nginx", "namespace": "taco-system" },
+                  { "path": "kubed", "namespace": "taco-system" },
+                  { "path": "kubernetes-addons", "namespace": "taco-system" }
+                ]
+          dependencies: [k8s-by-capi]


### PR DESCRIPTION
user cluster를 생성하는 workflow와 이를 위한 함수 수정입니다.

- 함수는 admin이나 usersite를 적절하게 사용하도록 구성함
- cluster-api-aws를 통해 다음의 내용을 완료할 수 있음
-- k8s 클러스터배포
-- 노드 lable 추가 (lma-enabled=true, .....)
-- 신규 k8s를 위한 argo-cd 준비 및 환경 초기화
- ingress-controller, kubed, kubernetes-addons 에 대한 배포
-- 이들은 테스트가 많이 이뤄지지 않았음
-- kubed와 ingress-controller는 다른 티켓이 있는 것으로 알고 있고 이어서 수행하기 바람