### PR TITLE
createapp: add cluster prefix to app names

### DIFF
--- a/templates/argo-cd/createapp-wftpl.yaml
+++ b/templates/argo-cd/createapp-wftpl.yaml
@@ -33,16 +33,18 @@ spec:
         ./argocd login $ARGO_SERVER --plaintext --insecure --username $ARGO_USERNAME \
         --password $ARGO_PASSWORD
 
+        export ARGOCD_APP_NAME=$(echo "${SITE_NAME:0:8}")-$PATH
+
         # check if app already exists.
-        ./argocd app get $PATH 
+        ./argocd app get $ARGOCD_APP_NAME
         if [[ $? -ne 0 ]]; then
           # create new application if not exists.
-          ./argocd app create $PATH --repo $REPO --revision $REVISION --path $SITE_NAME/$APP_NAME/$PATH --dest-namespace $NAMESPACE --dest-name $SITE_NAME --project $APP_NAME --label app=$APP_NAME --directory-recurse
+          ./argocd app create $ARGOCD_APP_NAME --repo $REPO --revision $REVISION --path $SITE_NAME/$APP_NAME/$PATH --dest-namespace $NAMESPACE --dest-name $SITE_NAME --project $APP_NAME --label app=$ARGOCD_APP_NAME --directory-recurse
         fi
 
-        ./argocd app set $PATH --sync-policy automated --auto-prune
-        ./argocd app sync $PATH --async
-        ./argocd app wait $PATH --health
+        ./argocd app set $ARGOCD_APP_NAME --sync-policy automated --auto-prune
+        ./argocd app sync $ARGOCD_APP_NAME --async
+        ./argocd app wait $ARGOCD_APP_NAME --health
       envFrom:
         - secretRef:
             name: "decapod-argocd-config"


### PR DESCRIPTION
Argocd 에 App을 생성할 때 타겟 클러스터 이름의 앞 8자리가 Prefix로 추가되어 App 이름으로 사용되도록 수정하였습니다.