### PR TITLE
move app_prefix to workflow param

### DIFF
--- a/templates/argo-cd/createapp-wftpl.yaml
+++ b/templates/argo-cd/createapp-wftpl.yaml
@@ -85,7 +85,6 @@ spec:
         arguments:
           parameters:
           - {name: app_group, value: "{{item.app_group}}"}
-          - {name: app_prefix, value: "{{item.app_prefix}}"}
           - {name: path, value: "{{item.path}}"}
           - {name: namespace, value: "{{item.namespace}}"}
           - {name: target_cluster, value: "{{item.target_cluster}}"}

--- a/templates/argo-cd/createapp-wftpl.yaml
+++ b/templates/argo-cd/createapp-wftpl.yaml
@@ -12,15 +12,13 @@ spec:
       value: "https://github.com/openinfradev/decapod-manifests"
     - name: revision
       value: "main"
+    - name: app_prefix
+      value: ""
   templates:
   - name: createApp
     inputs:
       parameters:
       - name: app_group
-      # TODO: if input default doesn't work, then try "template default"
-      # https://argoproj.github.io/argo-workflows/template-defaults/
-      - name: app_prefix
-        #value: "{{ workflow.parameters.site_name }}"
       - name: path
       - name: target_cluster  # set to site_name by default
       - name: namespace
@@ -45,9 +43,9 @@ spec:
         # TODO: another option is to set default app_prefix to 'site_name' and always apply that prefix.
         ARGOCD_APP_NAME=$PATH
         ARGOCD_APP_LABEL=$APP_GROUP
-        if [[ -n "{{inputs.parameters.app_prefix}}" ]]; then
-          ARGOCD_APP_NAME="{{inputs.parameters.app_prefix}}-$PATH"
-          ARGOCD_APP_LABEL="{{inputs.parameters.app_prefix}}-$APP_GROUP"
+        if [[ -n "{{workflow.parameters.app_prefix}}" ]]; then
+          ARGOCD_APP_NAME="{{workflow.parameters.app_prefix}}-$PATH"
+          ARGOCD_APP_LABEL="{{workflow.parameters.app_prefix}}-$APP_GROUP"
         fi
 
         # check if the argocd app already exists.

--- a/templates/decapod-apps/lma-uniformed-wftpl.yaml
+++ b/templates/decapod-apps/lma-uniformed-wftpl.yaml
@@ -18,6 +18,8 @@ spec:
       value: "https://github.com/openinfradev/decapod-manifests"
     - name: revision
       value: main
+    - name: app_prefix
+      value: ""
   templates:
   - name: prepare
     inputs: {}


### PR DESCRIPTION
app_prefix 가 개별 template level의 input param으로 되어있다보니, tks-flow/lma -> decapod-flow/lma -> create-app 과 같은 순서로 호출되는 경우, decapod-flow 쪽이 아닌 tks-flow 쪽에서 이 param을 override할 수 있는 방법이 없더군요.   그래서 workflow param으로 변경하여, tks-flow 쪽에서 override할 수 있게 수정하였습니다. 