### PR TITLE
set 'replace' sync-option for crd-only app

### DIFF
--- a/templates/argo-cd/createapp-wftpl.yaml
+++ b/templates/argo-cd/createapp-wftpl.yaml
@@ -55,7 +55,12 @@ spec:
           ./argocd app create $ARGOCD_APP_NAME --repo $REPO --revision $REVISION --path $SITE_NAME/$APP_GROUP/$PATH --dest-namespace $NAMESPACE --dest-name $TARGET_CLUSTER --project $APP_GROUP --label app=$ARGOCD_APP_LABEL --directory-recurse
         fi
 
-        ./argocd app set $ARGOCD_APP_NAME --sync-policy automated --auto-prune
+        # For crds-only app, set sync-option to 'replace'
+        if [[ $ARGOCD_APP_NAME == *crds ]]; then
+          ./argocd app set $ARGOCD_APP_NAME --sync-policy automated --auto-prune --sync-option Replace=true
+        else
+          ./argocd app set $ARGOCD_APP_NAME --sync-policy automated --auto-prune
+        fi
         ./argocd app sync $ARGOCD_APP_NAME --async
         ./argocd app wait $ARGOCD_APP_NAME --health
       envFrom:

--- a/templates/decapod-apps/lma-uniformed-wftpl.yaml
+++ b/templates/decapod-apps/lma-uniformed-wftpl.yaml
@@ -64,6 +64,7 @@ spec:
           - name: list
             value: |
               [
+                { "app_group": "lma", "path": "prometheus-operator-crds", "namespace": "lma", "target_cluster": "" },
                 { "app_group": "lma", "path": "prometheus-operator", "namespace": "lma", "target_cluster": "" }
               ]
         dependencies: []
@@ -78,6 +79,7 @@ spec:
             value: |
               [
                 { "app_group": "lma", "path": "eck-operator", "namespace": "elastic-system", "target_cluster": "" },
+                { "app_group": "lma", "path": "fluentbit-operator-crds", "namespace": "lma", "target_cluster": "" },
                 { "app_group": "lma", "path": "fluentbit-operator", "namespace": "lma", "target_cluster": "" }
               ]
         when: "{{workflow.parameters.logging_component}} == 'efk'"


### PR DESCRIPTION
https://github.com/openinfradev/tks-issues/issues/137

- Crd를 배포하는 ArgoCD App 에 한해 'Replace' option 적용하도록 create-app WF 수정
- lma workflow 에 추가로 crd-only app도 배포하도록 추가

(주의) https://github.com/openinfradev/decapod-base-yaml/pull/147 과 동시에 merge되어야 합니다.

참고로, servicemesh workflow 는 https://github.com/openinfradev/decapod-flow/pull/70 이 최종 merge되어야 본 PR 로직대로 수정 가능할 것 같습니다