### PR TITLE
make it fail when app filter doesn't match

### DIFF
--- a/templates/argo-cd/delete-apps-by-label-wftpl.yaml
+++ b/templates/argo-cd/delete-apps-by-label-wftpl.yaml
@@ -30,7 +30,7 @@ spec:
           echo "Found apps with label '$FILTER'.. Start deleting apps.."
         else
           echo "No such label: $FILTER. Skipping app removal.."
-          exit 0
+          exit 1
         fi
 
         deleted=False


### PR DESCRIPTION
Argo CD appgroup 삭제시, 요청한 label이 존재하지 않는 경우 실패 처리하도록 수정. 
Otherwise, 몇몇 Workflow에서 다음 스텝으로 진행되어버려서 문제가 되네요.