### PR TITLE
bugfix: check app status using exact matching

### DIFF
--- a/templates/argo-cd/delete-apps-wftpl.yaml
+++ b/templates/argo-cd/delete-apps-wftpl.yaml
@@ -102,7 +102,7 @@ spec:
         --password $ARGO_PASSWORD
 
         # Pre-check: validate if the app exists
-        if ! (./argocd app list | grep $APP); then
+        if ! (./argocd app list --output name | grep -E "^$APP$"); then
           echo "No such app: $APP. Skipping app removal.."
           exit 1
         fi
@@ -110,7 +110,7 @@ spec:
         echo "Found app '$APP'. Start deleting it.."
         ./argocd app delete $APP --cascade -y
 
-        while (./argocd app list | grep $APP )
+        while (./argocd app list --output name | grep -E "^$APP$" )
         do
           echo "Waiting 20 secs for the app to be deleted.."
           sleep 20


### PR DESCRIPTION
app 삭제시 상태 체크를 위해 exact matching을 사용하도록 수정합니다. 
금일 cluster-autoscaler 와 cluster-autoscaler-rbac 을 구분 못하는 버그가 발견되었기에 픽스합니다. 
(실제 WF를 돌려보진 못하고, 대신 grep 명령 테스트를 통해 정확한 키워드만 검출하는 것을 확인했습니다)