### PR TITLE
add secret patch role for argo

### DIFF
--- a/templates/argo-additional-rbac.yaml
+++ b/templates/argo-additional-rbac.yaml
@@ -38,6 +38,7 @@ rules:
   - create
   - delete
   - list
+  - patch
 - apiGroups:
   - "apps"
   resources:


### PR DESCRIPTION
Argo 네임스페이스의 default sa를 추가 권한 중 Secret에 대한 Patch 내용을 추가합니다.

참고: https://github.com/openinfradev/decapod-flow/blob/d82d97c835596e3c4d1e58b7f28d22abfe5734a3/templates/argo-cd/prepare-argocd-wftpl.yaml#L38