### PR TITLE
remove-admins-tools: fix wrong step name

### DIFF
--- a/templates/decapod-apps/remove-admin-tools-wftpl.yaml
+++ b/templates/decapod-apps/remove-admin-tools-wftpl.yaml
@@ -12,7 +12,7 @@ spec:
   templates:
     - name: process
       steps:
-      - - name: remove_admin-tools
+      - - name: remove-admin-tools
           templateRef:
             name: delete-apps
             template: DeleteAppsByLabel


### PR DESCRIPTION
RFC1123 규약에 맞지 않는 스텝 이름을 수정합니다.