### PR TITLE
[WIP] reduce cluster_id length

### DIFF
--- a/templates/decapod-apps/service-mesh-wf.yaml
+++ b/templates/decapod-apps/service-mesh-wf.yaml
@@ -193,9 +193,11 @@ spec:
             echo "[$date] $level     $msg"
           }
 
+          CLUSTER_ID={{workflow.parameters.cluster_id}}
           kube_params=""
-          if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          if [[ -n "${CLUSTER_ID}" ]]; then
+            CLUSTER_ID=$(echo "${CLUSTER_ID:0:8}")
+            kube_secret=$(kubectl get secret -n ${CLUSTER_ID} ${CLUSTER_ID}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /etc/kubeconfig
             kube_params+="--kubeconfig=/etc/kubeconfig"
@@ -252,9 +254,11 @@ spec:
             echo "[$date] $level     $msg"
           }
 
+          CLUSTER_ID={{workflow.parameters.cluster_id}}
           kube_params=""
-          if [[ -n "{{workflow.parameters.cluster_id}}" ]]; then
-            kube_secret=$(kubectl get secret -n {{workflow.parameters.cluster_id}} {{workflow.parameters.cluster_id}}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
+          if [[ -n "${CLUSTER_ID}" ]]; then
+            CLUSTER_ID=$(echo "${CLUSTER_ID:0:8}")
+            kube_secret=$(kubectl get secret -n ${CLUSTER_ID} ${CLUSTER_ID}-kubeconfig -o jsonpath="{.data.value}" | base64 -d)
             echo -e "kube_secret:\n$kube_secret" | head -n 5
             cat <<< "$kube_secret" > /etc/kubeconfig
             kube_params+="--kubeconfig=/etc/kubeconfig"


### PR DESCRIPTION
user cluster 에 접근하기 위해서 user cluster 의 kubeconfig 를 받아오는 부분이 있는데, admin 에서 관리하는 user cluster 의 namespace 가 cluster id 8자리로 줄어들면서 namespace 를 못찾는 문제가 발생했다.
cluster id 를 substr 으로 8자리로 자르는 로직을 추가했음.
e2e 테스트가 성공하는 것을 확인하고 merge 해야 함.