### PR TITLE
using structured kustomize document on infra-selection

### DIFF
--- a/templates/argo-cd/prepare-argocd-wftpl.yaml
+++ b/templates/argo-cd/prepare-argocd-wftpl.yaml
@@ -77,19 +77,9 @@ spec:
             ./argocd proj create sealed-secrets --dest "*,*" --src "*" --allow-cluster-resource "*/*"
           fi
 
-          ./argocd proj get tks-cluster-common
+          ./argocd proj get tks-cluster
           if [[ $? != 0 ]]; then
-            ./argocd proj create tks-cluster-common --dest "*,*" --src "*" --allow-cluster-resource "*/*"
-          fi
-
-          ./argocd proj get tks-cluster-aws
-          if [[ $? != 0 ]]; then
-            ./argocd proj create tks-cluster-aws --dest "*,*" --src "*" --allow-cluster-resource "*/*"
-          fi
-
-          ./argocd proj get tks-cluster-byoh
-          if [[ $? != 0 ]]; then
-            ./argocd proj create tks-cluster-byoh --dest "*,*" --src "*" --allow-cluster-resource "*/*"
+            ./argocd proj create tks-cluster --dest "*,*" --src "*" --allow-cluster-resource "*/*"
           fi
 
           ./argocd proj get admin-tools


### PR DESCRIPTION
kustomize의  다수의 리소스를 합치는 기능을 활용하여 다양한 변형을 지원할수 있다.
tks-cluster를 만드는 부분에서 infra를 함께 선택하여 aws나 byoh에 적용가능하다. (kustomization.yaml 작성시 포함한다. 다음은 aws 예시)

```
$  cat cluster/kustomization.yaml
resources:
  - ../base
  - ../infra/aws

transformers:
  - site-values.yaml
```

다음 두 pr이 동시 merge되어야 함
- https://github.com/openinfradev/decapod-site/pull/92
- https://github.com/openinfradev/decapod-base-yaml/pull/167
- https://github.com/openinfradev/tks-flow/pull/105
- https://github.com/openinfradev/decapod-flow/pull/96