### PR TITLE
Git 저장소 접근 정보를 Secret을 통해 얻습니다

### DIFF
--- a/templates/argo-cd/create-app-wftpl.yaml
+++ b/templates/argo-cd/create-app-wftpl.yaml
@@ -32,7 +32,7 @@ spec:
       imagePullPolicy: IfNotPresent
       command:
       - /bin/bash
-      - -c
+      - -cx
       - |
         # log into Argo CD server
         ./argocd login $ARGO_SERVER --plaintext --insecure --username $ARGO_USERNAME \
@@ -54,6 +54,10 @@ spec:
         # check if the argocd app already exists.
         ./argocd app get $ARGOCD_APP_NAME
         if [[ $? -ne 0 ]]; then
+          GIT_SVC_HTTP=${GIT_SVC_URL%://*}
+          GIT_SVC_BASE_URL=${GIT_SVC_URL#*//}
+          REPO="$GIT_SVC_HTTP://$GIT_SVC_BASE_URL/$USERNAME/$SITE_NAME-manifests"
+
           # create new application if it doesn't exist.
           ./argocd app create $ARGOCD_APP_NAME --repo $REPO --revision $REVISION --path $SITE_NAME/$APP_GROUP/$PATH --dest-namespace $NAMESPACE --dest-name $TARGET_CLUSTER --project $APP_GROUP --label app=$ARGOCD_APP_LABEL --directory-recurse
         fi
@@ -69,11 +73,11 @@ spec:
       envFrom:
         - secretRef:
             name: "decapod-argocd-config"
+        - secretRef:
+            name: "git-svc-token"
       env:
         - name: SITE_NAME
           value: "{{workflow.parameters.site_name}}"
-        - name: REPO
-          value: "{{workflow.parameters.manifest_repo_url}}"
         - name: REVISION
           value: "{{workflow.parameters.revision}}"
         - name: APP_GROUP


### PR DESCRIPTION
ArgoCD 대상 Git 저장소 주소 정보를 secret (git-svc-token)을 통해 얻어 사용하도록 수정하였습니다.