### PR TITLE
lma: fix typo error

### DIFF
--- a/templates/decapod-apps/lma-uniformed-wftpl.yaml
+++ b/templates/decapod-apps/lma-uniformed-wftpl.yaml
@@ -137,7 +137,7 @@ spec:
                 { "app_group": "lma", "path": "kubernetes-event-exporter", "namespace": "lma", "target_cluster": "" }
 
               ]
-        dependencies: [lma-operator]
+        dependencies: [lma-operators]
 
       - name: prepare-lma-etcd
         templateRef:


### PR DESCRIPTION
의존성 지정 과정에서 발생한 오타(lma-operators 에서 s 누락)를 수정합니다.