### PR TITLE
deploy-lma: remove process-exporter from lma deployment

### DIFF
--- a/templates/decapod-apps/lma-uniformed-wftpl.yaml
+++ b/templates/decapod-apps/lma-uniformed-wftpl.yaml
@@ -164,7 +164,6 @@ spec:
               [
                 { "app_group": "lma", "path": "prometheus", "namespace": "lma", "target_cluster": "" },
                 { "app_group": "lma", "path": "kube-state-metrics", "namespace": "lma", "target_cluster": "" },
-                { "app_group": "lma", "path": "prometheus-process-exporter", "namespace": "lma", "target_cluster": "" },
                 { "app_group": "lma", "path": "prometheus-pushgateway", "namespace": "lma", "target_cluster": "" },
                 { "app_group": "lma", "path": "prometheus-node-exporter", "namespace": "lma", "target_cluster": ""},
                 { "app_group": "lma", "path": "prometheus-adapter", "namespace": "lma", "target_cluster": "" },


### PR DESCRIPTION
LMA 구축시 process-exporter 설치를 제외합니다.
